### PR TITLE
Ability to add directives via Kirby cache

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4,6 +4,7 @@ namespace PedroBorges\Blade;
 
 use Exception;
 use F;
+use c;
 use Jenssegers\Blade\Blade;
 use Kirby;
 
@@ -75,6 +76,12 @@ class Compiler
         $this->directive('js', function ($path) {
             return "<?php echo js($path) ?>";
         });
+
+        if ($directives = c::get('blade.directives')){
+            foreach ($directives as $directiveKey => $directive) {
+                $this->directive($directiveKey, $directive);
+            }
+        }        
     }
 
      /**


### PR DESCRIPTION
Modified the registerDirectives method to include the ability to add directives via the Kirby cache rather than having to edit the plugin file itself.

Usage in config.php:
```php
c::set('blade.directives', [
	'directivename' => function($value){ return '<p>This is the directive function <?php echo $value; ?></p>';},
	'name' => function($value){return "<p><?php echo $value; ?></p>";}
]);
```

Template usage: 
```php
@directivename('input')
```

Output: 
```html
<p>This is the directive function input</p>
```

Signed-off-by: Oliver Belmont <obelmont@oliverbelmont.com>